### PR TITLE
feat: Merge trimming and mapping update; resolves #8, resolves #9, resolves #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Insert your code into the respective folders, i.e. `scripts`, `rules`, and `envs
     - [Authors](#authors)
     - [Table of Contents](#table-of-contents)
     - [Dependencies](#dependencies)
+    - [Notes](#notes)
     - [Usage](#usage)
         - [Step 1: Obtain a copy of this workflow](#step-1-obtain-a-copy-of-this-workflow)
         - [Step 2: Configure workflow](#step-2-configure-workflow)
@@ -34,6 +35,22 @@ Dependencies are automatically managed by conda environments. Only exception is 
 ```bash
 - NGmerge v0.3.0
 ```
+
+## Notes
+
+- The indext creation of bwa-mem2 is resource intesive (needs quotation): 
+
+```
+# Indexing the reference sequence (Requires 28N GB memory where N is the size of the reference sequence).
+./bwa-mem2 index [-p prefix] <in.fasta>
+Where 
+<in.fasta> is the path to reference sequence fasta file and 
+<prefix> is the prefix of the names of the files that store the resultant index. Default is in.fasta.
+```
+
+- bwa-mem2 mem uses around 4GB memory per thread
+
+- NGmerge merges/removes adapter from 3' end of the reads. The ends of the merged reads are defined by the 5' ends of the reads.
 
 ## Usage
 

--- a/config/example.config.yaml
+++ b/config/example.config.yaml
@@ -15,3 +15,51 @@ GRCh38:
 ### global variables ###
 
 TMPDIR: "" # path to directory for writing TMP files
+
+
+
+### trimming ###
+
+trimming_algorithm: "trimmomatic" #can be either NGmerge or trimmomatic
+
+#### NGmerge specific options ####9
+
+NGmerge:
+  MINLEN: 30 # min lenght of reads in additional filter steps
+
+#### trimmomatic specific options ####
+
+
+# Illuminaclip takes a fasta file with adapter sequences and removes them in the trimming step.
+# The adapter_files option takes either the path to a custom file </PATH/TO/CUSTOM/ADAPTER.fa>
+# or one of the following default files provided by Illumina and Trimmomatic:
+    # "NexteraPE-PE.fa",
+    # "TruSeq2-PE.fa",
+    # "TruSeq2-SE.fa",
+    # "TruSeq3-PE-2.fa",
+    # "TruSeq3-PE.fa",
+    # "TruSeq3-SE.fa",
+# For more information on Trimmomatic and its functionality can be found at:
+# http://www.usadellab.org/cms/?page=trimmomatic
+trimmers:
+  Illuminaclip: 
+    adapter_files: "TruSeq3-PE.fa" # filter not used if empty/invalid; can be either a path to a fasta file or the name of the default files;
+    seedMismatches: 2 # if not provided, defaults to 4
+    palindromeClipThreshold: 30 # if not provided, defaults to 30
+    simpleClipThreshold: 10 # if not provided, defaults to 10
+    minAdapterLength: 8 #optional argument, default ist 8
+    keepBothReads: True # if not provided, defaults to False
+  LEADING: 3  #(LEADING:3) Remove leading low quality or N bases (below quality 3); deactivated when set to 0
+  TRAILING: 3 #(TRAILING:3) Remove trailing low quality or N bases (below quality 3); deactivated when set to 0
+  SLIDINGWINDOW: #(SLIDINGWINDOW:4:15) Scan the read with a 4-base wide sliding window, cutting when the average quality per base drops below 15; deactivated when set to 0
+    window: 4 # deactivated when set to 0
+    quality_threshold: 15 
+  MINLEN: 30 #Drop reads below a ceartain length (e.g. 36 bp)  (MINLEN:36); deactivated when set to 0
+
+
+### Mapping ###
+
+# This option lets you add unpaired/singleton reads in the mapping step that were filtered,
+# but are either not paired or not merged. Otherwise these reads are not further processed.
+mapping:
+  all_data: False # default is False

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -9,6 +9,8 @@ include: "rules/common.smk"
 include: "rules/reference.smk"
 include: "rules/raw_input_QC.smk"
 include: "rules/bam_to_fastq.smk"
+include: "rules/trimming.smk"
+include: "rules/filtering.smk"
 include: "rules/mapping.smk"
 include: "rules/QualityControl.smk"
 

--- a/workflow/envs/cfDNA_prep.yaml
+++ b/workflow/envs/cfDNA_prep.yaml
@@ -6,6 +6,6 @@ channels:
 dependencies:
   - bedtools
   - python=3.8
-  - bwa
+  - bwa-mem2
   - samtools=1.14
 

--- a/workflow/rules/filtering.smk
+++ b/workflow/rules/filtering.smk
@@ -1,0 +1,36 @@
+rule filter_merged:
+    input:
+        unfiltered="results/{ID}/NGmerge/merged/{SAMPLE}_merged.unfiltered.fastq.gz"
+    output:
+        filtered=temp("results/{ID}/NGmerge/merged/{SAMPLE}_merged.filtered.fastq.gz")
+    params:
+        min_RL = config["NGmerge"]["MINLEN"]
+    conda:
+        "../envs/cfDNA_prep.yaml"
+    shell:
+        "awk 'BEGIN {{FS = \"\\t\" ; OFS = \"\\n\"}} {{header = $0 ; getline seq ; getline qheader ; getline qseq ; if (length(seq) >= {params.min_RL}) {{print header, seq, qheader, qseq}}}}' <( zcat {input.unfiltered} ) |  gzip -c > {output.filtered}"
+
+
+rule filter_interleaved:
+    input:
+        unfiltered="results/{ID}/NGmerge/nonmerged/{SAMPLE}_interleaved_noadapters.unfiltered.fastq.gz"
+    output:
+        filtered=temp("results/{ID}/NGmerge/nonmerged/{SAMPLE}_interleaved_noadapters.filtered.fastq.gz"),
+    params:
+        min_RL = config["NGmerge"]["MINLEN"]
+    conda:
+        "../envs/cfDNA_prep.yaml"
+    shell:
+        "awk 'BEGIN {{FS = \"\\t\" ; OFS = \"\\n\"}} {{header = $0 ; getline seq ; getline qheader ; getline qseq ; if (length(seq) >= {params.min_RL}) {{print header, seq, qheader, qseq}}}}' <( zcat {input.unfiltered} ) |  gzip -c > {output.filtered}"
+
+rule filter_single_read:
+    input:
+        unfiltered="results/{ID}/fastq/{SAMPLE}_single_read.fastq.gz"
+    output:
+        filtered=temp("results/{ID}/fastq/{SAMPLE}_single_read.filtered.fastq.gz")
+    params:
+        min_RL = config["NGmerge"]["MINLEN"]
+    conda:
+        "../envs/cfDNA_prep.yaml"
+    shell:
+        "awk 'BEGIN {{FS = \"\\t\" ; OFS = \"\\n\"}} {{header = $0 ; getline seq ; getline qheader ; getline qseq ; if (length(seq) >= {params.min_RL}) {{print header, seq, qheader, qseq}}}}' <( zcat {input.unfiltered} ) |  gzip -c > {output.filtered}"

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -1,91 +1,8 @@
-
-rule NGmerge:
+rule map_reads_bwa2:
     input:
-        unpack(get_NGmerge_input),
-        qual_table="resources/qual_profile.txt",
-    output:
-        merged=temp("results/{ID}/NGmerge/merged/{SAMPLE}_merged.unfiltered.fastq.gz"),
-        non_merged_1=temp("results/{ID}/NGmerge/nonmerged/{SAMPLE}_nonmerged_1.fastq.gz"),
-        non_merged_2=temp("results/{ID}/NGmerge/nonmerged/{SAMPLE}_nonmerged_2.fastq.gz"),
-    params:
-        non_merged_prefix="results/{ID}/NGmerge/nonmerged/{SAMPLE}_nonmerged",
-        minlen=20
-    log:
-        "results/logs/{ID}/NGmerge/{SAMPLE}.log",
-    conda:
-        "../envs/cfDNA_prep.yaml"
-    threads: 64
-    shell:
-        "set +o pipefail;"
-        "workflow/scripts/NGmerge -w {input.qual_table} -u 41 -d -e {params.minlen} -n {threads} -z "
-        "-1 {input.r1} -2 {input.r2} -o {output.merged} "
-        "-f {params.non_merged_prefix} -l {log} -v"
-
-
-rule NGmerge_adapter:
-    input:
-        non_merged_1="results/{ID}/NGmerge/nonmerged/{SAMPLE}_nonmerged_1.fastq.gz",
-        non_merged_2="results/{ID}/NGmerge/nonmerged/{SAMPLE}_nonmerged_2.fastq.gz",
-        qual_table="resources/qual_profile.txt",
-    output:
-        interleaved_output=temp("results/{ID}/NGmerge/nonmerged/{SAMPLE}_interleaved_noadapters.unfiltered.fastq.gz")
-    params:
-        adapt_minlen=1
-    log:
-        "results/logs/{ID}/NGmerge-adapter/{SAMPLE}.log",
-    conda:
-        "../envs/cfDNA_prep.yaml"
-    threads: 64
-    shell:
-        "set +o pipefail;"
-        "workflow/scripts/NGmerge -a -i -w {input.qual_table} -u 41 -d -e {params.adapt_minlen} -n {threads} -z "
-        "-1 {input.non_merged_1} -2 {input.non_merged_2} -o {output.interleaved_output}  "
-        "-c {log} -v"
-
-rule filter_interleaved:
-    input:
-        unfiltered="results/{ID}/NGmerge/nonmerged/{SAMPLE}_interleaved_noadapters.unfiltered.fastq.gz"
-    output:
-        filtered=temp("results/{ID}/NGmerge/nonmerged/{SAMPLE}_interleaved_noadapters.filtered.fastq.gz")
-    params:
-        min_RL = 30
-    conda:
-        "../envs/cfDNA_prep.yaml"
-    shell:
-        "awk 'BEGIN {{FS = \"\\t\" ; OFS = \"\\n\"}} {{header = $0 ; getline seq ; getline qheader ; getline qseq ; if (length(seq) >= {params.min_RL}) {{print header, seq, qheader, qseq}}}}' <( zcat {input.unfiltered} ) |  gzip -c > {output.filtered}"
-
-rule filter_merged:
-    input:
-        unfiltered="results/{ID}/NGmerge/merged/{SAMPLE}_merged.unfiltered.fastq.gz"
-    output:
-        filtered=temp("results/{ID}/NGmerge/merged/{SAMPLE}_merged.filtered.fastq.gz")
-    params:
-        min_RL = 30
-    conda:
-        "../envs/cfDNA_prep.yaml"
-    shell:
-        "awk 'BEGIN {{FS = \"\\t\" ; OFS = \"\\n\"}} {{header = $0 ; getline seq ; getline qheader ; getline qseq ; if (length(seq) >= {params.min_RL}) {{print header, seq, qheader, qseq}}}}' <( zcat {input.unfiltered} ) |  gzip -c > {output.filtered}"
-
-rule filter_single_read:
-    input:
-        unfiltered="results/{ID}/fastq/{SAMPLE}_single_read.fastq.gz"
-    output:
-        filtered=temp("results/{ID}/fastq/{SAMPLE}_single_read.filtered.fastq.gz")
-    params:
-        min_RL = 30
-    conda:
-        "../envs/cfDNA_prep.yaml"
-    shell:
-        "awk 'BEGIN {{FS = \"\\t\" ; OFS = \"\\n\"}} {{header = $0 ; getline seq ; getline qheader ; getline qseq ; if (length(seq) >= {params.min_RL}) {{print header, seq, qheader, qseq}}}}' <( zcat {input.unfiltered} ) |  gzip -c > {output.filtered}"
-
-
-rule map_reads:
-    input:
+        unpack(get_mapping_input),
         ref=lambda wc: get_reference(wc),
-        ref_index=lambda wc: get_reference(wc)+".amb",
-        merged="results/{ID}/NGmerge/merged/{SAMPLE}_merged.filtered.fastq.gz",
-        non_merged="results/{ID}/NGmerge/nonmerged/{SAMPLE}_interleaved_noadapters.filtered.fastq.gz",
-        single_read = "results/{ID}/fastq/{SAMPLE}_single_read.filtered.fastq.gz",
+        ref_index=lambda wc: multiext(get_reference(wc),".amb",".ann"),
     output:
         mapped_reads=temp("results/{ID}/mapped_reads/{SAMPLE}_all.{GENOME}.bam")
     params:
@@ -94,12 +11,9 @@ rule map_reads:
         "results/logs/{ID}/mapping/{SAMPLE}_all.{GENOME}.log",
     conda:
         "../envs/cfDNA_prep.yaml"
-    threads: 64
-    shell:
-        "((bwa mem -t {threads} -R \"{params.RG}\" {input.ref} {input.merged}; "
-        "bwa mem -t {threads} -R \"{params.RG}\" {input.ref} {input.non_merged} | grep -v \"^@\" || true ; "
-        "bwa mem -t {threads} -R \"{params.RG}\" {input.ref} {input.single_read}"
-        "| grep -v \"^@\" || true) | samtools view -b -o {output.mapped_reads} - ) 2>{log}"
+    threads: 32
+    script:
+        "../scripts/bwa-mem2_wrapper.py"
 
 rule mark_duplicates:
     input:

--- a/workflow/rules/reference.smk
+++ b/workflow/rules/reference.smk
@@ -14,17 +14,40 @@ rule get_reference:
         
 
 
-rule bwa_index:
+rule bwa_mem2_index:
     input:
         ref="resources/reference/{GENOME}.fa",
     output:
-        ref=multiext( "resources/reference/{GENOME}.fa", ".amb", ".ann", ".bwt", ".pac", ".sa"),
-    params:
-        algorithm="bwtsw",
+        ref=multiext( "resources/reference/{GENOME}.fa", ".amb", ".ann", ".pac", ),
+        #ref=multiext( "resources/reference/{GENOME}.fa", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     log:
        "logs/bwa_index-{GENOME}.log",
     conda:
         "../envs/cfDNA_prep.yaml"
-    threads: 1
+    threads: 16
     shell:
-        "bwa index -a {params.algorithm} {input.ref}"
+        "bwa-mem2 index {input.ref}"
+
+
+rule get_trimmomatic_adapters:
+    output:
+        "resources/adapter/NexteraPE-PE.fa",
+        "resources/adapter/TruSeq2-PE.fa",
+        "resources/adapter/TruSeq2-SE.fa",
+        "resources/adapter/TruSeq3-PE-2.fa",
+        "resources/adapter/TruSeq3-PE.fa",
+        "resources/adapter/TruSeq3-SE.fa",
+    params:
+        prefix="resources/adapter/",
+        URLs = [
+        "https://raw.githubusercontent.com/usadellab/Trimmomatic/main/adapters/NexteraPE-PE.fa",
+        "https://raw.githubusercontent.com/usadellab/Trimmomatic/main/adapters/TruSeq2-PE.fa",
+        "https://raw.githubusercontent.com/usadellab/Trimmomatic/main/adapters/TruSeq2-SE.fa",
+        "https://raw.githubusercontent.com/usadellab/Trimmomatic/main/adapters/TruSeq3-PE-2.fa",
+        "https://raw.githubusercontent.com/usadellab/Trimmomatic/main/adapters/TruSeq3-PE.fa",
+        "https://raw.githubusercontent.com/usadellab/Trimmomatic/main/adapters/TruSeq3-SE.fa",
+        ]
+    log:
+        "logs/get_trimmomatic_adapter.log"
+    shell:
+        "wget -P {params.prefix} {params.URLs} -o {log}"

--- a/workflow/rules/trimming.smk
+++ b/workflow/rules/trimming.smk
@@ -1,0 +1,95 @@
+rule NGmerge:
+    input:
+        unpack(get_trimming_input),
+        qual_table="resources/qual_profile.txt",
+    output:
+        merged=temp("results/{ID}/NGmerge/merged/{SAMPLE}_merged.unfiltered.fastq.gz"),
+        non_merged_1=temp("results/{ID}/NGmerge/nonmerged/{SAMPLE}_nonmerged_1.fastq.gz"),
+        non_merged_2=temp("results/{ID}/NGmerge/nonmerged/{SAMPLE}_nonmerged_2.fastq.gz"),
+    params:
+        non_merged_prefix="results/{ID}/NGmerge/nonmerged/{SAMPLE}_nonmerged",
+        minlen=20
+    log:
+        "logs/{ID}/NGmerge/{SAMPLE}.log",
+    conda:
+        "../envs/cfDNA_prep.yaml"
+    threads: 64
+    shell:
+        "set +o pipefail;"
+        "workflow/scripts/NGmerge -w {input.qual_table} -u 41 -d -e {params.minlen} -n {threads} -z "
+        "-1 {input.r1} -2 {input.r2} -o {output.merged} "
+        "-f {params.non_merged_prefix} -l {log} -v"
+
+
+rule NGmerge_adapter:
+    input:
+        non_merged_1="results/{ID}/NGmerge/nonmerged/{SAMPLE}_nonmerged_1.fastq.gz",
+        non_merged_2="results/{ID}/NGmerge/nonmerged/{SAMPLE}_nonmerged_2.fastq.gz",
+        qual_table="resources/qual_profile.txt",
+    output:
+        interleaved_output=temp("results/{ID}/NGmerge/nonmerged/{SAMPLE}_interleaved_noadapters.unfiltered.fastq.gz"),
+    params:
+        adapt_minlen=1
+    log:
+        "logs/{ID}/NGmerge-adapter/{SAMPLE}.log",
+    conda:
+        "../envs/cfDNA_prep.yaml"
+    threads: 64
+    shell:
+        "set +o pipefail;"
+        "workflow/scripts/NGmerge -a -i -w {input.qual_table} -u 41 -d -e {params.adapt_minlen} -n {threads} -z "
+        "-1 {input.non_merged_1} -2 {input.non_merged_2} -o {output.interleaved_output}  "
+        "-c {log} -v"
+
+rule trimmomatic_pe:
+    input:
+        unpack(get_trimming_input),
+    output:
+        r1=temp("results/{ID}/trimmed/trimmomatic/{SAMPLE}.1.fastq.gz"),
+        r2=temp("results/{ID}/trimmed/trimmomatic/{SAMPLE}.2.fastq.gz"),
+        # reads where trimming entirely removed the mate
+        r1_unpaired=temp("results/{ID}/trimmed/trimmomatic/{SAMPLE}.1.unpaired.fastq.gz"),
+        r2_unpaired=temp("results/{ID}/trimmed/trimmomatic/{SAMPLE}.2.unpaired.fastq.gz")
+    log:
+        "logs/{ID}/trimmomatic/{SAMPLE}.log"
+    params:
+        # list of trimmers (see manual)
+        trimmer = get_trimmomatic_trimmers(),
+        # optional parameters
+        extra="",
+        compression_level="-9"
+    threads:
+        32
+    # optional specification of memory usage of the JVM that snakemake will respect with global
+    # resource restrictions (https://snakemake.readthedocs.io/en/latest/snakefiles/rules.html#resources)
+    # and which can be used to request RAM during cluster job submission as `{resources.mem_mb}`:
+    # https://snakemake.readthedocs.io/en/latest/executing/cluster.html#job-properties
+    resources:
+        mem_mb=1024
+    wrapper:
+        "v1.1.0/bio/trimmomatic/pe"
+
+rule trimmomatic_se:
+    input:
+        "reads/{sample}.fastq.gz"  # input and output can be uncompressed or compressed
+    output:
+        temp("results/{ID}/trimmed/trimmomatic/{SAMPLE}.trimmed.fastq.gz",)
+    log:
+        "logs/{ID}/trimmomatic/{SAMPLE}.log"
+    params:
+        # list of trimmers (see manual)
+        trimmer=get_trimmomatic_trimmers(),
+        # optional parameters
+        extra="",
+        # optional compression levels from -0 to -9 and -11
+        compression_level="-9"
+    threads:
+        32
+    # optional specification of memory usage of the JVM that snakemake will respect with global
+    # resource restrictions (https://snakemake.readthedocs.io/en/latest/snakefiles/rules.html#resources)
+    # and which can be used to request RAM during cluster job submission as `{resources.mem_mb}`:
+    # https://snakemake.readthedocs.io/en/latest/executing/cluster.html#job-properties
+    resources:
+        mem_mb=1024
+    wrapper:
+        "v1.1.0/bio/trimmomatic/se"

--- a/workflow/scripts/README.md
+++ b/workflow/scripts/README.md
@@ -1,0 +1,3 @@
+# NGmerge executable
+
+The NGmerge executable was downloaded and compiled as described in the official documentation of [NGmerge v0.3](https://github.com/jsh58/NGmerge/releases/tag/v0.3). The main reason is an [outdated version of the bioconda recipe](https://github.com/jsh58/NGmerge/issues/20).

--- a/workflow/scripts/bwa-mem2_wrapper.py
+++ b/workflow/scripts/bwa-mem2_wrapper.py
@@ -1,0 +1,44 @@
+# Any Python script in the scripts folder will be able to import from this module.
+__author__ = "Sebastian Röner"
+__copyright__ = (
+    "Copyright 2022, Sebastian Röner"
+)
+__email__ = "sebastian.roener@bih-charite.de"
+__license__ = "MIT"
+
+
+from os import path
+from wsgiref.handlers import BaseCGIHandler
+
+from snakemake.shell import shell
+
+inputs = snakemake.input
+params = snakemake.params
+
+log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+
+# Check inputs/arguments.
+if not isinstance(snakemake.input.reads, str) and len(snakemake.input.reads) not in {
+    1,
+    2,
+}:
+    raise ValueError("input must have 1 (single-end) or 2 (paired-end) elements")
+
+
+non_merged_cmd = ""
+singleton_cmd = ""
+
+if snakemake.input.get("non_merged"):
+    non_merged_cmd = "bwa-mem2 mem -t {snakemake.threads} -R \"{snakemake.params.RG}\" {snakemake.input.ref} {snakemake.input.non_merged} | grep -v \"^@\" || true ; "
+
+if snakemake.input.get("single_reads"):
+    singleton_cmd = "bwa-mem2 mem -t {snakemake.threads} -R \"{snakemake.params.RG}\" {snakemake.input.ref} {snakemake.input.single_reads} | grep -v \"^@\" || true ; "
+
+base_cmd = f"((bwa-mem2 mem -t {{snakemake.threads}} -R \"{{snakemake.params.RG}}\" {{snakemake.input.ref}} {{snakemake.input.reads}}; \
+{non_merged_cmd}\
+{singleton_cmd}\
+) | samtools view -b -o {{snakemake.output.mapped_reads}} - ) 2>{{snakemake.log}}"
+
+
+shell(base_cmd)
+

--- a/workflow/scripts/common.py
+++ b/workflow/scripts/common.py
@@ -1,1 +1,0 @@
-# Any Python script in the scripts folder will be able to import from this module.


### PR DESCRIPTION
# Changes

## additions

- option to use trimmomatic for read processing
- add rule for downloading default illumna adapter sequences
- add rule for trimming PE reads
- add rule for trimming SE reads

- add option for using only paired end data (don't use singletons)

## refactor

- move trimming to separate snakefile
- move filtering to separate snakefile

## update

- update bwa to bwa-mem2 for mapping
- add wrapper to handle mapping  in a more flexible way
