### PR TITLE
fix: pin samtools version

### DIFF
--- a/workflow/envs/cfDNA_prep.yaml
+++ b/workflow/envs/cfDNA_prep.yaml
@@ -7,5 +7,5 @@ dependencies:
   - bedtools
   - python=3.8
   - bwa-mem2
-  - samtools
+  - samtools=1.17
 


### PR DESCRIPTION
Pin samtools version, which apparently fixes errors with missing dependencies (libdeflate, etc.)